### PR TITLE
Add export dropdown, and start seeing how many people are using the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You will need:
 
 1. Ensure that the webserver is pointing to the src directory.
 2. IMPORTANT : Remove the "management" and sql folders before making the site publicly accessable!
+3. Set the Google Analytics Id.
 
 #### MySql Database Setup (For publicly accessable websites)
 1. create a MySql database

--- a/src/Creator/version4/css/popup.css
+++ b/src/Creator/version4/css/popup.css
@@ -2,52 +2,6 @@
 
 /*===============POPUP BUTTONS=====================*/
 
-/* All the buttons */
-#menu{
-    width: 100px;
-    position: absolute;
-    right: 0px;
-    bottom: 0px;
-    z-index: 3;
-}
-
-.popupButton{
-    height: 3.5em;
-    width: 6em;
-    font-family: 'Lato', sans-serif;
-    text-align: left;
-    text-transform: uppercase;
-    padding-left: 1.25em;
-/*  Make the button oval shaped */
-    border-radius: 2.5em;
-    -moz-border-radius: 2.5em;
-    -webkit-border-radius: 2.5em;
-    color: hsl(200,10%,40%);
-    background-color: rgba(242, 242, 242, .8);
-/*  No top/bottom button shadow */
-    border-top: 0;
-    border-bottom: 0;
-    margin: 1px;
-}
-
-.popupButton:hover {
-  color: rgb(186, 0, 80);
-  background-color: rgba(254, 254, 254, .85);
-}
-
-.button_icone{
-	display: block;
-	line-height: 3em;
-	width: 3em;
-	height:3em;
-	text-align: right;
-	position: absolute;
-	right: 0;
-	top: 0;
-	padding-right: 1em;
-	opacity: 1;
-}
-
 .popupInnerButton{
     height: 55px;
     width: 150px;

--- a/src/Creator/version4/css/ui.css
+++ b/src/Creator/version4/css/ui.css
@@ -6,7 +6,7 @@
 /* Menu buttons, and dropdowns */
 
 #menu{
-    width: 6.1em;   /*Same as .popupButton, but with a little extra for the 1px margin .popupButton has*/
+    width: 6.2em;   /*Same as .popupButton, but with a little extra for the 1px margin .popupButton has*/
     position: absolute;
     right: 0px;
     bottom: 0px;
@@ -15,11 +15,10 @@
 
 .popupButton{
     height: 3.5em;
-    width: 6em;
+    width: 6.1em;
     font-family: 'Lato', sans-serif;
-    text-align: left;
+    text-align: center;
     text-transform: uppercase;
-    padding-left: 1.25em;
 /*  Make the button oval shaped */
     border-radius: 2.5em;
     -moz-border-radius: 2.5em;
@@ -48,4 +47,34 @@
     top: 0;
     padding-right: 1em;
     opacity: 1;
+}
+
+/* Hide and show dropdown menus*/
+.dropdown-content{
+    display: none;
+    position: absolute; /*Allows it to hover above other items on the page*/
+    width: 6.1em;         /*Same as .popupButton*/
+    background-color: rgba(242, 242, 242, .9);
+}
+.dropdown:hover .dropdown-content{
+    display: block;
+}
+.dropdown-content ul{
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+.dropdown-content a{
+    display: block;
+    border-top: 1px solid rgba(245, 245, 245, .6);
+    border-bottom: 1px solid rgba(148,155,153,.6);
+    height:  1.5em;
+    /* Make the text look correct */
+    text-align: center;
+    text-decoration: none;
+    color: hsl(200,10%,40%);
+}
+.dropdown-content a:hover{
+    color: rgb(186, 0, 80);
+    background-color: rgba(254, 254, 254, 1);
 }

--- a/src/Creator/version4/css/ui.css
+++ b/src/Creator/version4/css/ui.css
@@ -1,0 +1,51 @@
+/* ================= Static UI elements =================
+ * This is for elements that the user should see regardless of where they are on the site.
+ * For example, the menu buttons, and Points remaining display
+*/
+
+/* Menu buttons, and dropdowns */
+
+#menu{
+    width: 100px;
+    position: absolute;
+    right: 0px;
+    bottom: 0px;
+    z-index: 3;
+}
+
+.popupButton{
+    height: 3.5em;
+    width: 6em;
+    font-family: 'Lato', sans-serif;
+    text-align: left;
+    text-transform: uppercase;
+    padding-left: 1.25em;
+/*  Make the button oval shaped */
+    border-radius: 2.5em;
+    -moz-border-radius: 2.5em;
+    -webkit-border-radius: 2.5em;
+    color: hsl(200,10%,40%);
+    background-color: rgba(242, 242, 242, .8);
+/*  No top/bottom button shadow */
+    border-top: 0;
+    border-bottom: 0;
+    margin: 1px;
+}
+
+.popupButton:hover {
+  color: rgb(186, 0, 80);
+  background-color: rgba(254, 254, 254, .85);
+}
+
+.button_icone{
+    display: block;
+    line-height: 3em;
+    width: 3em;
+    height:3em;
+    text-align: right;
+    position: absolute;
+    right: 0;
+    top: 0;
+    padding-right: 1em;
+    opacity: 1;
+}

--- a/src/Creator/version4/css/ui.css
+++ b/src/Creator/version4/css/ui.css
@@ -6,7 +6,7 @@
 /* Menu buttons, and dropdowns */
 
 #menu{
-    width: 100px;
+    width: 6.1em;   /*Same as .popupButton, but with a little extra for the 1px margin .popupButton has*/
     position: absolute;
     right: 0px;
     bottom: 0px;

--- a/src/Creator/version4/index.php
+++ b/src/Creator/version4/index.php
@@ -26,7 +26,7 @@
 
         <div id="container">
 
-        	<!-- MAIN MENU - STATIC CONTENT-->       	
+            <!-- Ego/Morph MENU - STATIC CONTENT-->
         	<section id="primary" class="panel">
         		<nav id="main-nav">
     			<ul>
@@ -136,7 +136,7 @@
         <script><?php include "scripts/jquery/jquery-ui.min.js"; ?></script>
         <script><?php include "scripts/vegas/vegas.min.js"; ?></script>
         <script><?php include "scripts/ajax_helper.js"; ?></script>
-        <script><?php include "scripts/main_menu.js"; ?></script>
+        <script><?php include "scripts/panel_1.js"; ?></script>
         <script><?php include "scripts/ajaxManager.js"; ?></script>
         <script><?php include "scripts/popup.js"; ?></script>
         <script>

--- a/src/Creator/version4/index.php
+++ b/src/Creator/version4/index.php
@@ -158,5 +158,6 @@
                 });
             });
         </script>
+        <script><?php include "scripts/google_analytics.js.php"; ?></script>
     </body>
 </html>

--- a/src/Creator/version4/index.php
+++ b/src/Creator/version4/index.php
@@ -130,6 +130,7 @@
         <style><?php include "css/normalize/normalize.min.css"; ?></style>
         <style><?php include "css/lato.css"; ?></style>
         <style><?php include "css/icomoon.css"; ?></style>
+        <style><?php include "css/ui.css"; ?></style>
         <style><?php include "css/main7.css"; ?></style>
 
         <script><?php include "scripts/jquery/jquery.min.js"; ?></script>

--- a/src/Creator/version4/index.php
+++ b/src/Creator/version4/index.php
@@ -139,6 +139,7 @@
         <script><?php include "scripts/panel_1.js"; ?></script>
         <script><?php include "scripts/ajaxManager.js"; ?></script>
         <script><?php include "scripts/popup.js"; ?></script>
+        <script><?php include "scripts/ui.js"; ?></script>
         <script>
             $( function() {
                 //NAVIGATION JQUERRY
@@ -148,37 +149,6 @@
                     $(this).toggleClass("active");
                     $("#tertiary_infos").css('visibility','hidden');
                     return false;
-                });
-
-                var isMobile = (/android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(navigator.userAgent.toLowerCase()));
-
-                //background slideshow
-                //See here for more options:  http://vegas.jaysalvat.com/documentation/settings/
-                var desktopSlides = [
-                        { src: 'img/bg/bg1.jpg'},
-                        { src: 'img/bg/bg2.jpg'},
-                        { src: 'img/bg/bg3.jpg'},
-                        //These are all free (at least non-commercial) use images or images in the public domain
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/3/34/SFO_at_night.jpg'},     //Andrew Choy from Santa Clara, California (Creative Commons Attribution-Share Alike 2.0 Generic)
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/6/62/Starsinthesky.jpg'},    //Credit ESA (This is me giving credit, per the license)
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/0/00/Crab_Nebula.jpg'},                  //Credit NASA
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/7/7f/Ngc1999.jpg'},                      //Credit NASA
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/4/4e/Pleiades_large.jpg'},               //Credit NASA
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/c/c9/Sirius_A_and_B_artwork.jpg'},       //Credit NASA
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/5/57/Witness_the_Birth_of_a_Star.jpg'},  //Credit NASA
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Ngc6397_hst_blue_straggler.jpg'},   //Credit NASA
-                        { src: 'https://upload.wikimedia.org/wikipedia/commons/b/b4/The_Sun_by_the_Atmospheric_Imaging_Assembly_of_NASA%27s_Solar_Dynamics_Observatory_-_20100819.jpg'}  //Credit NASA
-                    ];
-                //Do not show the (data heavy) background images if on mobile
-                if(isMobile){
-                    desktopSlides=[{}]
-                };
-                $('body').vegas({
-                    timer: false,
-                    shuffle: true,
-                    delay: 60000,
-                    overlay: '<?php echo createDataURI("scripts/vegas/overlays/08.png","png"); ?>',
-                    slides: desktopSlides
                 });
             });
         </script>

--- a/src/Creator/version4/index.php
+++ b/src/Creator/version4/index.php
@@ -105,14 +105,19 @@
                     <!-- <span class="button_icone" data-icon="&#x2b;"></span> -->
                     Check
                 </button>
-                <button class="popupButton" id="exportTxtButton">
-                    <!-- <span class="button_icone" data-icon="&#x2c;"></span> -->
-                    TXT
-                </button>
-                <button class="popupButton" id="exportButton">
-                    <!-- <span class="button_icone" data-icon="&#x2c;"></span> -->
-                    PDF
-                </button>
+                <div class='dropdown'>
+                    <button class="popupButton" id="exportButton">
+                        <!-- <span class="button_icone" data-icon="&#x2c;"></span> -->
+                        Export
+                        &#x25BC;
+                    </button>
+                    <div class='dropdown-content'>
+                        <ul>
+                            <li><a id="exportPdfButton" href="#">PDF</a></li>
+                            <li><a id="exportTxtButton" href="#">TXT</a></li>
+                        </ul>
+                    </div>
+                </div>
                 <button class="popupButton" id="settingsButton">
                     <!-- <span class="button_icone" data-icon="&#x21;"></span> -->
                     Reset

--- a/src/Creator/version4/other/iconHelper.php
+++ b/src/Creator/version4/other/iconHelper.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ *  Icon helper functions
+ *
+ *  Instead of directly writing HTML, we use these helper functions whenever possible
+ */
+
+/**
+ * A class to help in adding icons to the page
+ *
+ * Use this instead of writing raw HTML.
+ */
+class Icon{
+    static $html_template = "<span class='{html_class}' id='{id}' data-icon='{icon}'></span>";
+    static $checked = '&#x2b;';
+    static $plus    = '&#x3a;';
+    static $minus   = '&#x3b;';
+    static $X       = '&#x39;';
+
+    /**
+     * A function to enable Python style string formatting
+     */
+    private function format($in_string,$vars){
+        $output = $in_string;
+        foreach ($vars as $key => $value) {
+            $output = str_replace('{'.$key.'}',$value,$output);
+        }
+        return $output;
+    }
+
+    /**
+     * Get the HTML for an icon.
+     */
+    public static function getHtml($class,$id,$icon){
+        $vars = array(
+            'html_class' => $class,
+            'id' => $id,
+            'icon' => $icon
+        );
+        return Icon::format(Icon::$html_template,$vars);
+    }
+}

--- a/src/Creator/version4/other/panelHelper.php
+++ b/src/Creator/version4/other/panelHelper.php
@@ -182,7 +182,11 @@ function endPanel(){
  */
 class li{
     private $html;
-    private $id;
+    private $id;            //Translates to html 'id ='
+    private $class;         //Translates to html 'class ='
+    private $cost;          //Translates to html 'data-cost ='
+    private $cost_isDefault;//Translates to html 'data-cost_isDefault ='
+    private $cost_units;    //Translates to html 'data-cost_units ='
 
     /**
      * Creat an li element.
@@ -192,8 +196,11 @@ class li{
      */
     function __construct($id,$class = ""){
         $this->id = $id;
-        $this->html  = "<li class='".$class."' id='".$id."'>";
-        $this->html .= $id;
+        $this->class = $class;
+
+        $this->cost = "";
+        $this->cost_isDefault = "";
+        $this->cost_units = "";
     }
 
     /**
@@ -206,6 +213,11 @@ class li{
      * @example $item->addCost(1): Gives "(1 cp)"
     */
     function addCost($cost,$isDefault = False, $units = "cp"){
+        $this->cost = $cost;
+        $this->cost_isDefault = $isDefault;
+        $this->cost_units = $units;
+
+
         $costDisplay = "(".$cost." ".$units.")";
         if($cost == 0){
             $costDisplay = "";
@@ -297,7 +309,11 @@ class li{
      * Get the final html of the li.
      */
     function getHtml(){
-        return $this->html . "</li>";
+        $output  = "<li class='".$this->class."' id='".$this->id."' data-cost='".$this->cost."' data-cost_isDefault='".$this->cost_isDefault."' data-cost_units='".$this->cost_units."' >";
+        $output .= $this->id;
+        $output .= $this->html;
+        $output .= "</li>";
+        return  $output;
     }
 }
 

--- a/src/Creator/version4/other/panelHelper.php
+++ b/src/Creator/version4/other/panelHelper.php
@@ -6,6 +6,7 @@
  */
 
 require_once('../other/bookPageLayer.php');
+require_once('../other/iconHelper.php');
 
 /**
  * A class to help in panel creation.
@@ -246,12 +247,11 @@ class li{
      * @param $isPlus    - Display the plus icon, or the checked icon.
      */
      function addPlusChecked($iconClass,$isChecked = False){
-        if($isChecked){
-            $this->html .= "<span class='addOrSelectedIcon ".$iconClass."' id='".$this->id."' data-icon='&#x2b;'></span>";
+        $icon = Icon::$checked;
+        if(!$isChecked){
+            $icon = Icon::$plus;
         }
-        else{
-            $this->html .= "<span class='addOrSelectedIcon ".$iconClass."' id='".$this->id."' data-icon='&#x3a;'></span>";
-        }
+        $this->html .= Icon::getHtml('addOrSelectedIcon '.$iconClass,$this->id,$icon);
      }
 
     /**
@@ -263,12 +263,11 @@ class li{
      * @param $isPlus    - Display the plus icon, or the minus icon.
      */
     function addPlusMinus($iconClass,$isPlus = True){
-        if($isPlus){
-            $this->html .= "<span class='addOrSelectedIcon ".$iconClass."' id='".$this->id."' data-icon='&#x3a;'></span>";
+        $icon = Icon::$plus;
+        if(!$isPlus){
+            $icon = Icon::$minus;
         }
-        else{
-            $this->html .= "<span class='addOrSelectedIcon ".$iconClass."' id='".$this->id."' data-icon='&#x3b;'></span>";
-        }
+        $this->html .= Icon::getHtml('addOrSelectedIcon '.$iconClass,$this->id,$icon);
      }
 
     /**
@@ -280,12 +279,11 @@ class li{
      * @param $isPlus    - Display the plus icon, or the 'X' icon.
      */
     function addPlusX($iconClass,$isPlus = True){
-        if($isPlus){
-            $this->html .= "<span class='addOrSelectedIcon ".$iconClass."' id='".$this->id."' data-icon='&#x3a;'></span>";
+        $icon = Icon::$plus;
+        if(!$isPlus){
+            $icon = Icon::$X;
         }
-        else{
-            $this->html .= "<span class='addOrSelectedIcon ".$iconClass."' id='".$this->id."' data-icon='&#x39;'></span>";
-        }
+        $this->html .= Icon::getHtml('addOrSelectedIcon '.$iconClass,$this->id,$icon);
      }
 
      /**
@@ -297,12 +295,11 @@ class li{
      * @param $isChecked - Display the checked icon, or a blank space.
      */
      function addCheckedBlank($iconClass,$isChecked = False){
-        if($isChecked){
-            $this->html .= "<span class='addOrSelectedIcon ".$iconClass."' id='".$this->id."' data-icon='&#x2b;'></span>";
+        $icon = Icon::$checked;
+        if(!$isChecked){
+            $icon = '';
         }
-        else{
-            $this->html .= "<span class='addOrSelectedIcon ".$iconClass."' id='".$this->id."'></span>";
-        }
+        $this->html .= Icon::getHtml('addOrSelectedIcon '.$iconClass,$this->id,$icon);
      }
 
     /**

--- a/src/Creator/version4/scripts/ajaxManager.js
+++ b/src/Creator/version4/scripts/ajaxManager.js
@@ -1166,26 +1166,6 @@ function removeSkill(node) {
         });
 }
 
-function setRemainingPoint(ajaxData){
-    // Hide creation data if not in creation mode, and Rez points if not in rez mode
-    if(ajaxData.creation_remain == "N/A")
-    {
-        $("#CP").css('display','none');
-        $("#AP").css('display','none');
-        $("#ASR").css('display','none');
-        $("#KSR").css('display','none');
-    }else{
-        $("#RZ").css('display','none');
-    }
-     $("#creation_remain").html(ajaxData.creation_remain);
-     $("#credit_remain").html(ajaxData.credit_remain);
-     $("#aptitude_remain").html(ajaxData.aptitude_remain);
-     $("#reputation_remain").html(ajaxData.reputation_remain);
-     $("#rez_remain").html(ajaxData.rez_remain);
-     $("#asr_remain").html(ajaxData.asr_remain);
-     $("#ksr_remain").html(ajaxData.ksr_remain);
-}
-
 //CREATE FOLDING LIST SESSION PREFERECES and SET THE RIGHT CSS FOR FOLDING LIST
 function setupFoldingList(){
      $('.foldingListSection').each(function(){

--- a/src/Creator/version4/scripts/google_analytics.js.php
+++ b/src/Creator/version4/scripts/google_analytics.js.php
@@ -1,0 +1,15 @@
+<?php
+//PHP Is Used in this javascript file to set the tracking ID from config.ini
+$php_dir = dirname(__FILE__) . '/../../../php/';
+require_once( $php_dir . 'EPConfigFile.php');
+$configValues = new EPConfigFile($php_dir . 'config.ini');
+$id = $configValues->getValue('GeneralValues','googleAnalyticsId');
+?>
+
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', '<?php echo $id; ?>', 'auto');
+ga('send', 'pageview');

--- a/src/Creator/version4/scripts/panel_1.js
+++ b/src/Creator/version4/scripts/panel_1.js
@@ -1,4 +1,4 @@
-// ================= Main Menu =================
+// ================= Panel 1 =================
 //Requires: ajax_helper.js
 
 //BACKGROUND

--- a/src/Creator/version4/scripts/popup.js
+++ b/src/Creator/version4/scripts/popup.js
@@ -45,45 +45,6 @@ function loadPopup(popup_name,url,clickToClose=false,reloadOnClose=false){
 }
 
 //**************************************************
-//**********Popup Buttons (on main page)**********
-
-//click on button load on main page
-$("#loadButton").click(function() {
-    loadPopup("#load_popup","popup-contents/load.php");
-});
-
-// Save button
-$("#saveButton").click(function() {
-    // window.open("./other/save.php");
-    loadPopup("#save_popup","popup-contents/save_popup.php");
-});
-
-// Check button
-$("#validateButton").click(function() {
-        loadPopup("#validation_popup", "popup-contents/validation.php",true);
-});
-
-// Txt export button
-$("#exportTxtButton").click(function() {
-        window.open("./exporter/txtExporter.php");
-});
-
-// Pdf export button
-$("#exportButton").click(function() {
-        window.open("./exporter/pdfExporterV2_fpdf.php");
-});
-
-// Reset button
-$("#settingsButton").click(function() {
-        loadPopup("reload_popup","popup-contents/reset.php",false,true);
-});
-
-// About button
-$("#aboutButton").click(function() {
-        loadPopup("#about_popup", "popup-contents/about.php",true);
-});
-
-//**************************************************
 
 // Close some popups by clicking on them
 $("#popup").click(function() {

--- a/src/Creator/version4/scripts/ui.js
+++ b/src/Creator/version4/scripts/ui.js
@@ -78,7 +78,7 @@ var desktopSlides = [
         { src: 'img/bg/bg2.jpg'},
         { src: 'img/bg/bg3.jpg'},
         //These are all free (at least non-commercial) use images or images in the public domain
-        { src: 'https://upload.wikimedia.org/wikipedia/commons/3/34/SFO_at_night.jpg'},     //Andrew Choy from Santa Clara, California (Creative Commons Attribution-Share Alike 2.0 Generic)
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/d/d6/San_Francisco_International_Airport_at_night.jpg'},     //Andrew Choy from Santa Clara, California (Creative Commons Attribution-Share Alike 2.0 Generic)
         { src: 'https://upload.wikimedia.org/wikipedia/commons/6/62/Starsinthesky.jpg'},    //Credit ESA (This is me giving credit, per the license)
         { src: 'https://upload.wikimedia.org/wikipedia/commons/0/00/Crab_Nebula.jpg'},                  //Credit NASA
         { src: 'https://upload.wikimedia.org/wikipedia/commons/7/7f/Ngc1999.jpg'},                      //Credit NASA

--- a/src/Creator/version4/scripts/ui.js
+++ b/src/Creator/version4/scripts/ui.js
@@ -1,0 +1,101 @@
+// ================= Static UI elements =================
+// This is for elements that the user should see regardless of where they are on the site.
+// For example, the menu buttons, and Points remaining display
+// Requires: popup.js
+// Requires: scripts/vegas/vegas.min.js
+
+//Note:  This script is optimized to be included via a PHP include statement.  It uses PHP, and references relative paths!
+
+//**************************************************
+//**********Menu Buttons**********
+
+// Load button
+$("#loadButton").click(function() {
+    loadPopup("#load_popup","popup-contents/load.php");
+});
+
+// Save button
+$("#saveButton").click(function() {
+    // window.open("./other/save.php");
+    loadPopup("#save_popup","popup-contents/save_popup.php");
+});
+
+// Check button
+$("#validateButton").click(function() {
+        loadPopup("#validation_popup", "popup-contents/validation.php",true);
+});
+
+// Txt export button
+$("#exportTxtButton").click(function() {
+        window.open("./exporter/txtExporter.php");
+});
+
+// Pdf export button
+$("#exportButton").click(function() {
+        window.open("./exporter/pdfExporterV2_fpdf.php");
+});
+
+// Reset button
+$("#settingsButton").click(function() {
+        loadPopup("reload_popup","popup-contents/reset.php",false,true);
+});
+
+// About button
+$("#aboutButton").click(function() {
+        loadPopup("#about_popup", "popup-contents/about.php",true);
+});
+
+//**************************************************
+
+// Adjust the points remaining display
+function setRemainingPoint(ajaxData){
+    // Hide creation data if not in creation mode, and Rez points if not in rez mode
+    if(ajaxData.creation_remain == "N/A")
+    {
+        $("#CP").css('display','none');
+        $("#AP").css('display','none');
+        $("#ASR").css('display','none');
+        $("#KSR").css('display','none');
+    }else{
+        $("#RZ").css('display','none');
+    }
+     $("#creation_remain").html(ajaxData.creation_remain);
+     $("#credit_remain").html(ajaxData.credit_remain);
+     $("#aptitude_remain").html(ajaxData.aptitude_remain);
+     $("#reputation_remain").html(ajaxData.reputation_remain);
+     $("#rez_remain").html(ajaxData.rez_remain);
+     $("#asr_remain").html(ajaxData.asr_remain);
+     $("#ksr_remain").html(ajaxData.ksr_remain);
+}
+
+//**************************************************
+//**********Background Slideshow**********
+var isMobile = (/android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(navigator.userAgent.toLowerCase()));
+
+//See here for more options:  http://vegas.jaysalvat.com/documentation/settings/
+var desktopSlides = [
+        { src: 'img/bg/bg1.jpg'},
+        { src: 'img/bg/bg2.jpg'},
+        { src: 'img/bg/bg3.jpg'},
+        //These are all free (at least non-commercial) use images or images in the public domain
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/3/34/SFO_at_night.jpg'},     //Andrew Choy from Santa Clara, California (Creative Commons Attribution-Share Alike 2.0 Generic)
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/6/62/Starsinthesky.jpg'},    //Credit ESA (This is me giving credit, per the license)
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/0/00/Crab_Nebula.jpg'},                  //Credit NASA
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/7/7f/Ngc1999.jpg'},                      //Credit NASA
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/4/4e/Pleiades_large.jpg'},               //Credit NASA
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/c/c9/Sirius_A_and_B_artwork.jpg'},       //Credit NASA
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/5/57/Witness_the_Birth_of_a_Star.jpg'},  //Credit NASA
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Ngc6397_hst_blue_straggler.jpg'},   //Credit NASA
+        { src: 'https://upload.wikimedia.org/wikipedia/commons/b/b4/The_Sun_by_the_Atmospheric_Imaging_Assembly_of_NASA%27s_Solar_Dynamics_Observatory_-_20100819.jpg'}  //Credit NASA
+    ];
+//Do not show the (data heavy) background images if on mobile
+if(isMobile){
+    desktopSlides=[{}]
+};
+$('body').vegas({
+    timer: false,
+    shuffle: true,
+    delay: 60000,
+    overlay: '<?php echo createDataURI("scripts/vegas/overlays/08.png","png"); ?>',
+    slides: desktopSlides
+});

--- a/src/Creator/version4/scripts/ui.js
+++ b/src/Creator/version4/scripts/ui.js
@@ -31,7 +31,7 @@ $("#exportTxtButton").click(function() {
 });
 
 // Pdf export button
-$("#exportButton").click(function() {
+$("#exportPdfButton").click(function() {
         window.open("./exporter/pdfExporterV2_fpdf.php");
 });
 

--- a/src/php/config.ini
+++ b/src/php/config.ini
@@ -8,6 +8,8 @@ versionNumber = 1.49
 versionNumber_type = f
 versionNumberMin = 0.91
 versionNumberMin_type = f
+googleAnalyticsId = UA-463340-1
+googleAnalyticsId_type = s
 [SQLValues]
 // databasePDO = 'sqlite:../../../sql/FullDatabase.sqlite3'
 databasePDO = "mysql:dbname=EclipsePhaseData;host=localhost;port=3306"


### PR DESCRIPTION
# CSS / Javascript Rearrangement
The idea is all the static elements are moved to `ui.css`.  This isn't complete, especially since there are questions about if things like the popup frame size should be in `ui.css` or `popup.css`.  This also moves some javascript that had crept into the main html page to `ui.js`.

# Export Menu
Instead of having buttons that just say "PDF" or "TXT" there is now an export drop down menu.  Given that I'm trying to collaborate with [Eldrich.host](Eldrich.host) on a common transfer format, being able to add more export options without menu bloat is important.

# Google Analytics
I realized I had no way to see if anyone is even using the site.  To that end, I've added google analytics tracking.  The tracking code is basic does not actually see what features users are using or not, so it can't even tell how often someone loads a profile, or if they're exporting characters or not.  Users can change the tracking cookie via `config.ini`

# To Do
* Have Analytics track if users are actually using site features
* Add a survey to see what users want
* New user assistance:
  * Add tutorial
  * Add explanations for what each item means
* Site layout:
  * Change layout to be more user friendly
  * (possibly) Convert to using a top menu bar instead of the buttons on the right
 * Improve mobile layout
* Improve site responsiveness
  * Add/Remove check marks in real time.
  * Display information about something by hovering over it
    * Working on this by adding a `description` tag to the `li` element, but need to make sure that everything is escaped properly
